### PR TITLE
Standalone ui-scrollable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  # - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/addon/components/ui-scrollable.js
+++ b/addon/components/ui-scrollable.js
@@ -11,19 +11,12 @@ export default Ember.Component.extend(Composable, {
   ps: false,
   // attrs }
 
-  didInsertElement() {
-    this._super(...arguments);
-
-    let ps = this.get('ps');
-
-    if (ps) {
-      if (typeof ps === 'boolean') {
-        ps = {};
-      }
-
+  ui: {
+    init() {
+      let ps = this.get('ps');
       let scrollable = this.$().addClass('ui-scrollable--ps');
       let viewport = this.$().children('.ui-scrollable__viewport')
-        .perfectScrollbar(ps)
+        .perfectScrollbar(typeof ps === 'boolean' ? {} : ps)
         .get(0);
       let rails = scrollable
         .find('.ps-scrollbar-x-rail, .ps-scrollbar-y-rail')
@@ -35,16 +28,40 @@ export default Ember.Component.extend(Composable, {
       viewport.contains = function(element) {
         return rails.includes(element) || HTMLElement.prototype.contains.call(this, element);
       };
+    },
+
+    update() {
+      this.$().children('.ui-scrollable__viewport').perfectScrollbar('update');
+    },
+
+    destroy() {
+      let viewport = this.$().children('.ui-scrollable__viewport').get(0);
+
+      this.$().removeClass(viewport.className.split(/\s+/).slice(1).concat('ui-scrollable--ps').join(' '));
+      this.$().children('.ui-scrollable__viewport').perfectScrollbar('destroy');
+    }
+  },
+
+  didRender() {
+    this._super(...arguments);
+
+    let ps = this.get('ps');
+
+    if (ps) {
+      this.ui.init.call(this);
+    }
+    else {
+      this.ui.destroy.call(this);
     }
   },
 
   willDestroyElement() {
     this._super(...arguments);
 
-    this.$().children('.ui-scrollable__viewport').perfectScrollbar('destroy');
+    this.ui.destroy.call(this);
   },
 
   update() {
-    this.$().children('.ui-scrollable__viewport').perfectScrollbar('update');
+    this.ui.update.call(this);
   }
 });

--- a/addon/components/ui-table/tbody-each.js
+++ b/addon/components/ui-table/tbody-each.js
@@ -62,7 +62,6 @@ export default Body.extend({
   refreshBuffer: observerOnce('modelNormalized.@each.isSelected', function() {
     let model = this.get('modelNormalized');
     let buffer = this.get('buffer');
-    let cursors = this.get('bufferCursors');
 
     buffer.forEach(item => {
       item.set('model', model.objectAt(item.get('index')));

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  overflow: hidden;
 }
 
 #chrome {
@@ -79,4 +80,20 @@ body.ember-application .ui-table__th {
 }
 
 body.ember-application .ui-table__td {
+}
+
+ul {
+  margin: 0;
+  padding-left: 25px;
+}
+
+.panel {
+  max-width: 320px;
+  max-height: 480px;
+  margin: 50px auto;
+  display: flex;
+  flex-direction: column;
+}
+
+body.ember-application .ui-scrollable {
 }

--- a/tests/dummy/app/templates/ui-scrollable.hbs
+++ b/tests/dummy/app/templates/ui-scrollable.hbs
@@ -1,7 +1,17 @@
-{{#ui-scrollable}}
-  <ul>
-    {{#each application.model as |item|}}
-      <li>Item {{item.attributes.first-name}}</li>
-    {{/each}}
-  </ul>
-{{/ui-scrollable}}
+<div class="panel">
+  {{let ps=(Boolean true)}}
+
+  <div class="header">
+    <h1>Header</h1>
+    <div>
+      <button {{action ps.toggle}}>Toggle PS: {{ps.value}}</button>
+    </div>
+  </div>
+  {{#ui-scrollable ps=ps.value}}
+    <ul>
+      {{#each application.model as |item|}}
+        <li>{{item.firstName}}</li>
+      {{/each}}
+    </ul>
+  {{/ui-scrollable}}
+</div>

--- a/vendor/ember-ui-kit/ui-scrollable.css
+++ b/vendor/ember-ui-kit/ui-scrollable.css
@@ -1,12 +1,20 @@
 .ui-scrollable {
   position: relative;
-  overflow: visible !important;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .ui-scrollable__viewport {
-  max-width: 100%;
-  max-height: 100%;
-  min-height: 100%;
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  max-height: 100%; /* Safari Fix */
+  overflow: auto;
+}
+
+.ui-scrollable__scroller {
+  overflow: hidden;
 }
 
 .ui-scrollable .ps-scrollbar-x-rail,

--- a/vendor/ember-ui-kit/ui-table.css
+++ b/vendor/ember-ui-kit/ui-table.css
@@ -17,6 +17,11 @@
     opacity: 0.6;
   }
 
+  .ui-table:hover .ps-scrollbar-x-rail,
+  .ui-table:hover .ps-scrollbar-y-rail {
+    opacity: 0.6;
+  }
+
 .ui-table__thead {
   box-sizing: content-box;
   position: absolute;


### PR DESCRIPTION
ui-scrollable was previously built for ui-table scroll sync. This PR allows the component to be used alone.